### PR TITLE
Refactor notebook import logic for testability

### DIFF
--- a/app/src/main/java/com/kindler/ImportState.kt
+++ b/app/src/main/java/com/kindler/ImportState.kt
@@ -1,0 +1,9 @@
+package com.kindler
+
+enum class ImportState {
+    INITIAL,
+    LOADING_BOOK_LIST,
+    LOADING_HIGHLIGHTS,
+    FINISHED,
+    ERROR
+}

--- a/app/src/main/java/com/kindler/NotebookImportStateMachine.kt
+++ b/app/src/main/java/com/kindler/NotebookImportStateMachine.kt
@@ -1,0 +1,81 @@
+package com.kindler
+
+class NotebookImportStateMachine {
+
+    var state: ImportState = ImportState.INITIAL
+        private set
+
+    private val books: MutableList<BookEntry> = mutableListOf()
+    private var index: Int = 0
+
+    val currentBookIndex: Int
+        get() = index
+
+    val totalBooks: Int
+        get() = books.size
+
+    fun startImport() {
+        state = ImportState.LOADING_BOOK_LIST
+        index = 0
+        books.clear()
+    }
+
+    fun onBooksParsed(parsedBooks: List<BookEntry>): BooksUpdateResult {
+        if (state != ImportState.LOADING_BOOK_LIST) {
+            return BooksUpdateResult.InvalidState(state)
+        }
+
+        books.clear()
+        books.addAll(parsedBooks)
+        index = 0
+
+        return if (books.isEmpty()) {
+            state = ImportState.FINISHED
+            BooksUpdateResult.NoBooks
+        } else {
+            state = ImportState.LOADING_HIGHLIGHTS
+            BooksUpdateResult.Ready(books.first())
+        }
+    }
+
+    fun currentBook(): BookEntry? = books.getOrNull(index)
+
+    fun advanceToNextBook(): HighlightProcessingResult {
+        if (state != ImportState.LOADING_HIGHLIGHTS) {
+            return HighlightProcessingResult.InvalidState(state)
+        }
+
+        if (books.isEmpty()) {
+            state = ImportState.ERROR
+            return HighlightProcessingResult.InvalidState(state)
+        }
+
+        index++
+        return if (index < books.size) {
+            HighlightProcessingResult.Next(books[index])
+        } else {
+            state = ImportState.FINISHED
+            HighlightProcessingResult.Completed
+        }
+    }
+
+    fun markFinished() {
+        state = ImportState.FINISHED
+    }
+
+    fun markError() {
+        state = ImportState.ERROR
+    }
+
+    sealed class BooksUpdateResult {
+        object NoBooks : BooksUpdateResult()
+        data class Ready(val nextBook: BookEntry) : BooksUpdateResult()
+        data class InvalidState(val state: ImportState) : BooksUpdateResult()
+    }
+
+    sealed class HighlightProcessingResult {
+        data class Next(val nextBook: BookEntry) : HighlightProcessingResult()
+        object Completed : HighlightProcessingResult()
+        data class InvalidState(val state: ImportState) : HighlightProcessingResult()
+    }
+}

--- a/app/src/main/java/com/kindler/NotebookJsonParser.kt
+++ b/app/src/main/java/com/kindler/NotebookJsonParser.kt
@@ -1,0 +1,30 @@
+package com.kindler
+
+import org.json.JSONArray
+
+object NotebookJsonParser {
+
+    fun parseBookEntries(bookDataJson: String): Result<List<BookEntry>> = runCatching {
+        val rawBooksArray = JSONArray(bookDataJson)
+        (0 until rawBooksArray.length()).map { index ->
+            val bookObject = rawBooksArray.getJSONObject(index)
+            BookEntry(
+                asin = bookObject.getString("asin"),
+                title = bookObject.getString("title"),
+                author = bookObject.getString("author"),
+                lastAccessedDate = bookObject.getString("lastAccessedDate")
+            )
+        }
+    }
+
+    fun parseHighlights(highlightsJson: String): Result<List<HighlightEntry>> = runCatching {
+        val highlightsArray = JSONArray(highlightsJson)
+        (0 until highlightsArray.length()).map { index ->
+            val highlightObject = highlightsArray.getJSONObject(index)
+            HighlightEntry(
+                highlight = highlightObject.getString("highlight"),
+                note = highlightObject.getString("note")
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kindler/NotebookModels.kt
+++ b/app/src/main/java/com/kindler/NotebookModels.kt
@@ -1,0 +1,13 @@
+package com.kindler
+
+data class BookEntry(
+    val asin: String,
+    val title: String,
+    val author: String,
+    val lastAccessedDate: String
+)
+
+data class HighlightEntry(
+    val highlight: String,
+    val note: String
+)

--- a/app/src/test/java/com/kindler/NotebookImportStateMachineTest.kt
+++ b/app/src/test/java/com/kindler/NotebookImportStateMachineTest.kt
@@ -1,0 +1,73 @@
+package com.kindler
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotebookImportStateMachineTest {
+
+    private val sampleBooks = listOf(
+        BookEntry("ASIN1", "Book One", "Author A", "2023-01-01"),
+        BookEntry("ASIN2", "Book Two", "Author B", "2023-02-02")
+    )
+
+    @Test
+    fun startImport_initializesState() {
+        val stateMachine = NotebookImportStateMachine()
+
+        stateMachine.startImport()
+
+        assertEquals(ImportState.LOADING_BOOK_LIST, stateMachine.state)
+        assertEquals(0, stateMachine.currentBookIndex)
+        assertEquals(0, stateMachine.totalBooks)
+    }
+
+    @Test
+    fun onBooksParsed_withNoBooks_finishesProcess() {
+        val stateMachine = NotebookImportStateMachine()
+        stateMachine.startImport()
+
+        val result = stateMachine.onBooksParsed(emptyList())
+
+        assertTrue(result is NotebookImportStateMachine.BooksUpdateResult.NoBooks)
+        assertEquals(ImportState.FINISHED, stateMachine.state)
+    }
+
+    @Test
+    fun onBooksParsed_withBooks_movesToHighlightState() {
+        val stateMachine = NotebookImportStateMachine()
+        stateMachine.startImport()
+
+        val result = stateMachine.onBooksParsed(sampleBooks)
+
+        assertTrue(result is NotebookImportStateMachine.BooksUpdateResult.Ready)
+        assertEquals(ImportState.LOADING_HIGHLIGHTS, stateMachine.state)
+        assertEquals(sampleBooks.first(), stateMachine.currentBook())
+        assertEquals(sampleBooks.size, stateMachine.totalBooks)
+    }
+
+    @Test
+    fun advanceToNextBook_iteratesThroughAllBooks() {
+        val stateMachine = NotebookImportStateMachine()
+        stateMachine.startImport()
+        stateMachine.onBooksParsed(sampleBooks)
+
+        val firstAdvance = stateMachine.advanceToNextBook()
+        assertTrue(firstAdvance is NotebookImportStateMachine.HighlightProcessingResult.Next)
+        assertEquals(sampleBooks[1], (firstAdvance as NotebookImportStateMachine.HighlightProcessingResult.Next).nextBook)
+        assertEquals(sampleBooks[1], stateMachine.currentBook())
+
+        val secondAdvance = stateMachine.advanceToNextBook()
+        assertTrue(secondAdvance is NotebookImportStateMachine.HighlightProcessingResult.Completed)
+        assertEquals(ImportState.FINISHED, stateMachine.state)
+    }
+
+    @Test
+    fun advanceToNextBook_whenCalledInWrongState_returnsInvalidState() {
+        val stateMachine = NotebookImportStateMachine()
+
+        val result = stateMachine.advanceToNextBook()
+
+        assertTrue(result is NotebookImportStateMachine.HighlightProcessingResult.InvalidState)
+    }
+}

--- a/app/src/test/java/com/kindler/NotebookJsonParserTest.kt
+++ b/app/src/test/java/com/kindler/NotebookJsonParserTest.kt
@@ -1,0 +1,67 @@
+package com.kindler
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotebookJsonParserTest {
+
+    @Test
+    fun parseBookEntries_returnsExpectedBooks() {
+        val json = """
+            [
+                {
+                    "asin": "ASIN1",
+                    "title": "Book One",
+                    "author": "Author A",
+                    "lastAccessedDate": "2023-01-01"
+                },
+                {
+                    "asin": "ASIN2",
+                    "title": "Book Two",
+                    "author": "Author B",
+                    "lastAccessedDate": "2023-02-02"
+                }
+            ]
+        """.trimIndent()
+
+        val result = NotebookJsonParser.parseBookEntries(json)
+
+        assertTrue(result.isSuccess)
+        val books = result.getOrThrow()
+        assertEquals(2, books.size)
+        assertEquals(BookEntry("ASIN1", "Book One", "Author A", "2023-01-01"), books[0])
+        assertEquals(BookEntry("ASIN2", "Book Two", "Author B", "2023-02-02"), books[1])
+    }
+
+    @Test
+    fun parseBookEntries_invalidJson_returnsFailure() {
+        val result = NotebookJsonParser.parseBookEntries("not valid json")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun parseHighlights_returnsExpectedEntries() {
+        val json = """
+            [
+                {
+                    "highlight": "Highlight text",
+                    "note": "Note text"
+                },
+                {
+                    "highlight": "Another highlight",
+                    "note": ""
+                }
+            ]
+        """.trimIndent()
+
+        val result = NotebookJsonParser.parseHighlights(json)
+
+        assertTrue(result.isSuccess)
+        val highlights = result.getOrThrow()
+        assertEquals(2, highlights.size)
+        assertEquals(HighlightEntry("Highlight text", "Note text"), highlights[0])
+        assertEquals(HighlightEntry("Another highlight", ""), highlights[1])
+    }
+}


### PR DESCRIPTION
## Summary
- move import state tracking into a dedicated `NotebookImportStateMachine`
- extract JSON parsing into reusable helpers and shared book/highlight models
- update `MainActivity` to use the new helpers and add unit tests for the pure logic

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cddff3b85c833283e1dc00853c6e78