### PR TITLE
Aggregate highlights into single JSON store

### DIFF
--- a/app/src/main/java/com/kindler/HighlightsFileStore.kt
+++ b/app/src/main/java/com/kindler/HighlightsFileStore.kt
@@ -1,0 +1,85 @@
+package com.kindler
+
+import java.io.File
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import org.json.JSONArray
+import org.json.JSONObject
+
+class HighlightsFileStore(
+    private val outputFile: File,
+    private val flushThreshold: Int = DEFAULT_FLUSH_THRESHOLD
+) {
+
+    private val storedBooks = mutableListOf<BookHighlights>()
+
+    @Throws(IOException::class)
+    fun reset() {
+        storedBooks.clear()
+        if (outputFile.exists() && !outputFile.delete()) {
+            throw IOException("Failed to delete existing highlights file: ${outputFile.absolutePath}")
+        }
+    }
+
+    @Throws(IOException::class)
+    fun addBookHighlights(
+        asin: String,
+        title: String,
+        highlights: List<HighlightEntry>
+    ) {
+        storedBooks.add(BookHighlights(asin, title, highlights))
+        if (flushThreshold > 0 && storedBooks.size % flushThreshold == 0) {
+            writeToFile(storedBooks)
+        }
+    }
+
+    @Throws(IOException::class)
+    fun flush() {
+        if (storedBooks.isEmpty()) {
+            return
+        }
+        writeToFile(storedBooks)
+    }
+
+    @Throws(IOException::class)
+    private fun writeToFile(books: List<BookHighlights>) {
+        val snapshot = books.toList()
+        val payload = JSONObject().apply {
+            put("bookCount", snapshot.size)
+            put("books", JSONArray().apply {
+                snapshot.forEach { book ->
+                    put(JSONObject().apply {
+                        put("asin", book.asin)
+                        put("title", book.title)
+                        put("highlights", JSONArray().apply {
+                            book.highlights.forEach { highlight ->
+                                put(JSONObject().apply {
+                                    put("highlight", highlight.highlight)
+                                    put("note", highlight.note)
+                                })
+                            }
+                        })
+                    })
+                }
+            })
+        }
+        outputFile.parentFile?.let { parent ->
+            if (!parent.exists() && !parent.mkdirs()) {
+                throw IOException("Failed to create directory for highlights file: ${parent.absolutePath}")
+            }
+        }
+        outputFile.outputStream().buffered().use { stream ->
+            stream.write(payload.toString(2).toByteArray(StandardCharsets.UTF_8))
+        }
+    }
+
+    private data class BookHighlights(
+        val asin: String,
+        val title: String,
+        val highlights: List<HighlightEntry>
+    )
+
+    companion object {
+        const val DEFAULT_FLUSH_THRESHOLD = 100
+    }
+}

--- a/app/src/test/java/com/kindler/HighlightsFileStoreTest.kt
+++ b/app/src/test/java/com/kindler/HighlightsFileStoreTest.kt
@@ -1,0 +1,106 @@
+package com.kindler
+
+import java.io.File
+import java.nio.file.Files
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HighlightsFileStoreTest {
+
+    @Test
+    fun `does not write file before flush threshold is reached`() {
+        val tempDir = Files.createTempDirectory("highlight-store-test").toFile()
+        try {
+            val outputFile = File(tempDir, "highlights.json")
+            val store = HighlightsFileStore(outputFile, flushThreshold = 2)
+
+            store.addBookHighlights("ASIN-1", "Book One", listOf(HighlightEntry("Highlight 1", "Note 1")))
+            assertFalse(outputFile.exists())
+
+            store.addBookHighlights("ASIN-2", "Book Two", listOf(HighlightEntry("Highlight 2", "Note 2")))
+            assertTrue(outputFile.exists())
+
+            val json = JSONObject(outputFile.readText())
+            assertEquals(2, json.getInt("bookCount"))
+            val books = json.getJSONArray("books")
+            assertEquals(2, books.length())
+
+            val firstBook = books.getJSONObject(0)
+            assertEquals("ASIN-1", firstBook.getString("asin"))
+            assertEquals("Book One", firstBook.getString("title"))
+            val firstHighlights = firstBook.getJSONArray("highlights")
+            assertEquals(1, firstHighlights.length())
+            val highlight = firstHighlights.getJSONObject(0)
+            assertEquals("Highlight 1", highlight.getString("highlight"))
+            assertEquals("Note 1", highlight.getString("note"))
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `flush writes remaining books even when below threshold`() {
+        val tempDir = Files.createTempDirectory("highlight-store-test").toFile()
+        try {
+            val outputFile = File(tempDir, "highlights.json")
+            val store = HighlightsFileStore(outputFile, flushThreshold = 3)
+
+            store.addBookHighlights("ASIN-3", "Book Three", emptyList())
+            assertFalse(outputFile.exists())
+
+            store.flush()
+            assertTrue(outputFile.exists())
+
+            val json = JSONObject(outputFile.readText())
+            assertEquals(1, json.getInt("bookCount"))
+            val books = json.getJSONArray("books")
+            assertEquals(1, books.length())
+            assertEquals(0, books.getJSONObject(0).getJSONArray("highlights").length())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `reset clears stored books and deletes existing file`() {
+        val tempDir = Files.createTempDirectory("highlight-store-test").toFile()
+        try {
+            val outputFile = File(tempDir, "highlights.json")
+            val store = HighlightsFileStore(outputFile, flushThreshold = 1)
+
+            store.addBookHighlights("ASIN-4", "Book Four", listOf(HighlightEntry("Highlight", "Note")))
+            assertTrue(outputFile.exists())
+
+            store.reset()
+            assertFalse(outputFile.exists())
+
+            store.addBookHighlights("ASIN-5", "Book Five", listOf(HighlightEntry("Another", "Note")))
+            store.flush()
+
+            val json = JSONObject(outputFile.readText())
+            assertEquals(1, json.getInt("bookCount"))
+            val firstBook = json.getJSONArray("books").getJSONObject(0)
+            assertEquals("ASIN-5", firstBook.getString("asin"))
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `flush does not create file when no highlights are present`() {
+        val tempDir = Files.createTempDirectory("highlight-store-test").toFile()
+        try {
+            val outputFile = File(tempDir, "highlights.json")
+            val store = HighlightsFileStore(outputFile)
+
+            store.flush()
+
+            assertFalse(outputFile.exists())
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace per-ASIN persistence with a HighlightsFileStore that aggregates imports into a single kindle_highlights.json
- call the store from MainActivity, deferring resets until the first parsed highlights and only flushing when data exists
- add unit coverage for HighlightsFileStore reset, flushing, and avoidance of empty writes

## Testing
- ./gradlew test *(fails: Android SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f24759948332818e216a0d38534e