### PR TITLE
Add highlights list to BookEntry

### DIFF
--- a/app/src/main/java/com/kindler/MainActivity.kt
+++ b/app/src/main/java/com/kindler/MainActivity.kt
@@ -228,7 +228,13 @@ class MainActivity : AppCompatActivity() {
                     return
                 }
                 try {
-                    highlightsFileStore.addBookHighlights(asin, bookTitle, highlights)
+                    val bookEntry = currentBook ?: BookEntry(
+                        asin = asin,
+                        title = bookTitle,
+                        author = "",
+                        lastAccessedDate = ""
+                    )
+                    highlightsFileStore.addBookHighlights(bookEntry, highlights)
                 } catch (e: IOException) {
                     Log.e(TAG, "Failed to persist highlights for ASIN $asin", e)
                 }

--- a/app/src/main/java/com/kindler/NotebookModels.kt
+++ b/app/src/main/java/com/kindler/NotebookModels.kt
@@ -4,7 +4,8 @@ data class BookEntry(
     val asin: String,
     val title: String,
     val author: String,
-    val lastAccessedDate: String
+    val lastAccessedDate: String,
+    val highlights: List<HighlightEntry> = emptyList()
 )
 
 data class HighlightEntry(

--- a/app/src/test/java/com/kindler/HighlightsFileStoreTest.kt
+++ b/app/src/test/java/com/kindler/HighlightsFileStoreTest.kt
@@ -17,48 +17,87 @@ class HighlightsFileStoreTest {
             val outputFile = File(tempDir, "highlights.json")
             val store = HighlightsFileStore(outputFile, flushThreshold = 2)
 
-            store.addBookHighlights("ASIN-1", "Book One", listOf(HighlightEntry("Highlight 1", "Note 1")))
+            store.addBookHighlights(
+                BookEntry("ASIN-1", "Book One", "Author One", "2023-01-01"),
+                listOf(HighlightEntry("Highlight 1", "Note 1"))
+            )
             assertFalse(outputFile.exists())
 
-            store.addBookHighlights("ASIN-2", "Book Two", listOf(HighlightEntry("Highlight 2", "Note 2")))
+            store.addBookHighlights(
+                BookEntry("ASIN-2", "Book Two", "Author Two", "2023-02-02"),
+                listOf(HighlightEntry("Highlight 2", "Note 2"))
+            )
             assertTrue(outputFile.exists())
 
-            val json = JSONObject(outputFile.readText())
-            assertEquals(2, json.getInt("bookCount"))
-            val books = json.getJSONArray("books")
-            assertEquals(2, books.length())
+            val lines = outputFile.readLines()
+            assertEquals(2, lines.size)
 
-            val firstBook = books.getJSONObject(0)
+            val firstBook = JSONObject(lines[0])
             assertEquals("ASIN-1", firstBook.getString("asin"))
             assertEquals("Book One", firstBook.getString("title"))
+            assertEquals("Author One", firstBook.getString("author"))
+            assertEquals("2023-01-01", firstBook.getString("lastAccessedDate"))
             val firstHighlights = firstBook.getJSONArray("highlights")
             assertEquals(1, firstHighlights.length())
             val highlight = firstHighlights.getJSONObject(0)
             assertEquals("Highlight 1", highlight.getString("highlight"))
             assertEquals("Note 1", highlight.getString("note"))
+
+            val secondBook = JSONObject(lines[1])
+            assertEquals("ASIN-2", secondBook.getString("asin"))
+            assertEquals("Book Two", secondBook.getString("title"))
+            assertEquals("Author Two", secondBook.getString("author"))
+            assertEquals("2023-02-02", secondBook.getString("lastAccessedDate"))
+            val secondHighlights = secondBook.getJSONArray("highlights")
+            assertEquals(1, secondHighlights.length())
+            val secondHighlight = secondHighlights.getJSONObject(0)
+            assertEquals("Highlight 2", secondHighlight.getString("highlight"))
+            assertEquals("Note 2", secondHighlight.getString("note"))
         } finally {
             tempDir.deleteRecursively()
         }
     }
 
     @Test
-    fun `flush writes remaining books even when below threshold`() {
+    fun `flush appends remaining books when below threshold`() {
         val tempDir = Files.createTempDirectory("highlight-store-test").toFile()
         try {
             val outputFile = File(tempDir, "highlights.json")
             val store = HighlightsFileStore(outputFile, flushThreshold = 3)
 
-            store.addBookHighlights("ASIN-3", "Book Three", emptyList())
+            store.addBookHighlights(
+                BookEntry("ASIN-3", "Book Three", "Author Three", "2023-03-03"),
+                emptyList()
+            )
             assertFalse(outputFile.exists())
 
             store.flush()
             assertTrue(outputFile.exists())
 
-            val json = JSONObject(outputFile.readText())
-            assertEquals(1, json.getInt("bookCount"))
-            val books = json.getJSONArray("books")
-            assertEquals(1, books.length())
-            assertEquals(0, books.getJSONObject(0).getJSONArray("highlights").length())
+            var lines = outputFile.readLines()
+            assertEquals(1, lines.size)
+
+            val firstFlushBook = JSONObject(lines[0])
+            assertEquals("ASIN-3", firstFlushBook.getString("asin"))
+            assertEquals("Author Three", firstFlushBook.getString("author"))
+            assertEquals("2023-03-03", firstFlushBook.getString("lastAccessedDate"))
+            assertEquals(0, firstFlushBook.getJSONArray("highlights").length())
+
+            store.addBookHighlights(
+                BookEntry("ASIN-6", "Book Six", "Author Six", "2023-06-06"),
+                listOf(HighlightEntry("Highlight 6", "Note 6"))
+            )
+            store.flush()
+
+            lines = outputFile.readLines()
+            assertEquals(2, lines.size)
+            assertEquals(firstFlushBook.toString(), JSONObject(lines[0]).toString())
+            val appendedBook = JSONObject(lines[1])
+            assertEquals("ASIN-6", appendedBook.getString("asin"))
+            assertEquals("Author Six", appendedBook.getString("author"))
+            assertEquals("2023-06-06", appendedBook.getString("lastAccessedDate"))
+            val appendedHighlights = appendedBook.getJSONArray("highlights")
+            assertEquals(1, appendedHighlights.length())
         } finally {
             tempDir.deleteRecursively()
         }
@@ -71,19 +110,27 @@ class HighlightsFileStoreTest {
             val outputFile = File(tempDir, "highlights.json")
             val store = HighlightsFileStore(outputFile, flushThreshold = 1)
 
-            store.addBookHighlights("ASIN-4", "Book Four", listOf(HighlightEntry("Highlight", "Note")))
+            store.addBookHighlights(
+                BookEntry("ASIN-4", "Book Four", "Author Four", "2023-04-04"),
+                listOf(HighlightEntry("Highlight", "Note"))
+            )
             assertTrue(outputFile.exists())
 
             store.reset()
             assertFalse(outputFile.exists())
 
-            store.addBookHighlights("ASIN-5", "Book Five", listOf(HighlightEntry("Another", "Note")))
+            store.addBookHighlights(
+                BookEntry("ASIN-5", "Book Five", "Author Five", "2023-05-05"),
+                listOf(HighlightEntry("Another", "Note"))
+            )
             store.flush()
 
-            val json = JSONObject(outputFile.readText())
-            assertEquals(1, json.getInt("bookCount"))
-            val firstBook = json.getJSONArray("books").getJSONObject(0)
+            val lines = outputFile.readLines()
+            assertEquals(1, lines.size)
+            val firstBook = JSONObject(lines[0])
             assertEquals("ASIN-5", firstBook.getString("asin"))
+            assertEquals("Author Five", firstBook.getString("author"))
+            assertEquals("2023-05-05", firstBook.getString("lastAccessedDate"))
         } finally {
             tempDir.deleteRecursively()
         }


### PR DESCRIPTION
## Summary
- extend `BookEntry` with a `highlights` list defaulting to empty
- update `HighlightsFileStore` to persist highlight batches via the `BookEntry.highlights` property

## Testing
- ./gradlew test *(fails: Android SDK not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d580e941e883329bb12d8f7a3a8b43