### PR TITLE
Add navigation drawer and separate import activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:theme="@style/Theme.MyApplication"
         tools:targetApi="31">
         <activity
+            android:name=".ImportActivity"
+            android:exported="false" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/kindler/ImportActivity.kt
+++ b/app/src/main/java/com/kindler/ImportActivity.kt
@@ -1,0 +1,276 @@
+package com.kindler
+
+import android.annotation.SuppressLint
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import java.io.File
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+
+
+class ImportActivity : AppCompatActivity() {
+
+    companion object {
+        private const val TAG = "ImportActivity"
+        private const val BASE_URL = "https://read.amazon.com/"
+        private const val NOTEBOOK_URL = "${BASE_URL}notebook"
+        private const val HIGHLIGHT_URL_PREFIX = "${BASE_URL}notebook?asin="
+        private const val HIGHLIGHT_URL_SUFFIX = "&contentLimitState="
+        private const val SIGN_IN_URL_PREFIX = "https://www.amazon.com/ap/signin"
+        private const val HIGHLIGHTS_FILE_NAME = "kindle_highlights.json"
+    }
+
+    private val importStateMachine = NotebookImportStateMachine()
+    private lateinit var myWebView: WebView
+    private lateinit var overlayLayout: LinearLayout
+    private lateinit var startImportButton: Button
+    private lateinit var promptTextView: TextView
+    private lateinit var highlightsFileStore: HighlightsFileStore
+    private var highlightsStoreResetThisRun = false
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_import)
+
+        myWebView = findViewById(R.id.webView)
+        overlayLayout = findViewById(R.id.overlayLayout)
+        startImportButton = findViewById(R.id.startImportButton)
+        promptTextView = findViewById(R.id.promptTextView)
+        highlightsFileStore = HighlightsFileStore(File(filesDir, HIGHLIGHTS_FILE_NAME))
+
+        myWebView.settings.javaScriptEnabled = true
+        myWebView.addJavascriptInterface(WebAppInterface(), "AndroidInterface")
+
+        myWebView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                Log.i(TAG, "New page finished loading: $url")
+                Log.d(TAG, "Current state: ${importStateMachine.state}")
+                when (importStateMachine.state) {
+                    ImportState.INITIAL -> checkLoginAndUrlStatus()
+                    ImportState.LOADING_BOOK_LIST -> verifyUrlAndProceed(NOTEBOOK_URL, url, "extract_book_list.js")
+                    ImportState.LOADING_HIGHLIGHTS -> verifyUrlAndProceed(HIGHLIGHT_URL_PREFIX, url, "extract_highlights.js")
+                    else -> {
+                        // No action needed for other states
+                    }
+                }
+            }
+        }
+
+        startImportButton.setOnClickListener {
+            overlayLayout.visibility = View.GONE
+            startImportProcess()
+        }
+        
+        myWebView.loadUrl(NOTEBOOK_URL)
+    }
+
+    private fun checkLoginAndUrlStatus() {
+        val script = """
+        (function() {
+            var isLoggedIn = document.getElementById('kp-notebook-library') !== null;
+            var isOnNotebookPage = window.location.href.startsWith('${NOTEBOOK_URL}');
+            var isOnSignInPage = window.location.href.startsWith('${SIGN_IN_URL_PREFIX}');
+            if (typeof AndroidInterface !== 'undefined' && AndroidInterface.reportUiStatus) {
+                AndroidInterface.reportUiStatus(isLoggedIn, isOnNotebookPage, isOnSignInPage);
+            }
+        })();
+        """.trimIndent()
+        myWebView.evaluateJavascript(script, null)
+    }
+    
+    private fun terminateProcess(finalState: ImportState) {
+        if (finalState != ImportState.FINISHED && finalState != ImportState.ERROR) {
+            Log.w(TAG, "terminateProcess called with non-terminal state: $finalState")
+            return
+        }
+        when (finalState) {
+            ImportState.FINISHED -> importStateMachine.markFinished()
+            ImportState.ERROR -> importStateMachine.markError()
+            else -> { /* Already validated above */ }
+        }
+        runOnUiThread {
+            overlayLayout.visibility = View.VISIBLE
+            checkLoginAndUrlStatus()
+        }
+    }
+
+    private fun startImportProcess(){
+        highlightsStoreResetThisRun = false
+        importStateMachine.startImport()
+        Log.d(TAG, "Starting import process. Loading book list page: $NOTEBOOK_URL")
+        myWebView.loadUrl(NOTEBOOK_URL)
+    }
+
+    private fun verifyUrlAndProceed(expectedUrlPrefix: String, actualUrl: String?, scriptToLoad: String) {
+        if (actualUrl?.startsWith(expectedUrlPrefix) == true) {
+            loadAndExecuteJavascript(myWebView, scriptToLoad)
+        } else {
+            Log.e(TAG, "URL Mismatch! State: ${importStateMachine.state}, Expected prefix: '$expectedUrlPrefix', Actual: '$actualUrl'.")
+            terminateProcess(ImportState.ERROR)
+        }
+    }
+
+    private fun loadNextBookHighlights() {
+        if (importStateMachine.state != ImportState.LOADING_HIGHLIGHTS) {
+            Log.e(TAG, "loadNextBookHighlights called in a wrong state ${importStateMachine.state}. Aborting.")
+            return
+        }
+        val book = importStateMachine.currentBook()
+        if (book == null) {
+            Log.e(
+                TAG,
+                "loadNextBookHighlights called with invalid index ${importStateMachine.currentBookIndex}. " +
+                        "Book list size: ${importStateMachine.totalBooks}. Aborting."
+            )
+            return
+        }
+        val highlightsUrl = "$HIGHLIGHT_URL_PREFIX${book.asin}$HIGHLIGHT_URL_SUFFIX"
+        Log.i(TAG, "Loading highlights for book '${book.title}' (ASIN: ${book.asin}) from $highlightsUrl")
+        myWebView.loadUrl(highlightsUrl)
+    }
+
+    private fun loadAndExecuteJavascript(webView: WebView?, scriptName: String) {
+        val javascript: String
+        try {
+            val inputStream = assets.open(scriptName)
+            val size = inputStream.available()
+            val buffer = ByteArray(size)
+            inputStream.read(buffer)
+            inputStream.close()
+            javascript = String(buffer, StandardCharsets.UTF_8)
+        } catch (e: IOException) {
+            Log.e(TAG, "Error reading $scriptName from assets", e)
+            terminateProcess(ImportState.ERROR)
+            return
+        }
+        Log.d(TAG, "Executing $scriptName")
+        webView?.evaluateJavascript(javascript, null)
+    }
+
+    private fun ensureHighlightsStoreReady(): Boolean {
+        if (highlightsStoreResetThisRun) {
+            return true
+        }
+        return try {
+            highlightsFileStore.reset()
+            highlightsStoreResetThisRun = true
+            true
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to reset highlights storage", e)
+            terminateProcess(ImportState.ERROR)
+            false
+        }
+    }
+
+    inner class WebAppInterface {
+        @JavascriptInterface
+        fun reportUiStatus(isLoggedIn: Boolean, isOnNotebookPage: Boolean, isOnSignInPage: Boolean) {
+            runOnUiThread {
+                if (isLoggedIn && isOnNotebookPage) {
+                    promptTextView.text = "Import your Kindle books and highlights."
+                    startImportButton.visibility = View.VISIBLE
+                } else if (isOnSignInPage || isOnNotebookPage) {
+                    promptTextView.text = "Please log in to your Amazon account to continue."
+                    startImportButton.visibility = View.GONE
+                } else{
+                    promptTextView.text = "Please navigate to your Kindle Notebook page."
+                    startImportButton.visibility = View.GONE
+                }
+            }
+        }
+
+        @JavascriptInterface
+        fun processBookData(bookDataJson: String) {
+            if (importStateMachine.state != ImportState.LOADING_BOOK_LIST) return
+            Log.i(TAG, "Received book list data. Processing...")
+            NotebookJsonParser.parseBookEntries(bookDataJson)
+                .onSuccess { parsedBooks ->
+                    Log.i(TAG, "Total books found on main page: ${parsedBooks.size}")
+                    when (val result = importStateMachine.onBooksParsed(parsedBooks)) {
+                        NotebookImportStateMachine.BooksUpdateResult.NoBooks -> {
+                            Log.i(TAG, "No books found in the list. Finishing process.")
+                            terminateProcess(ImportState.FINISHED)
+                        }
+                        is NotebookImportStateMachine.BooksUpdateResult.Ready -> {
+                            runOnUiThread { loadNextBookHighlights() }
+                        }
+                        is NotebookImportStateMachine.BooksUpdateResult.InvalidState -> {
+                            Log.e(TAG, "Received book data while in invalid state ${result.state}.")
+                            terminateProcess(ImportState.ERROR)
+                        }
+                    }
+                }
+                .onFailure { e ->
+                    Log.e(TAG, "Error processing book list data: ", e)
+                    terminateProcess(ImportState.ERROR)
+                }
+        }
+
+        @JavascriptInterface
+        fun processBookHighlights(highlightsJson: String) {
+            if (importStateMachine.state != ImportState.LOADING_HIGHLIGHTS) return
+            val currentBook = importStateMachine.currentBook()
+            if (currentBook == null || currentBook.asin.isEmpty())  {
+                Log.e(TAG, "No book data available for the current book. Aborting.")
+                terminateProcess(ImportState.ERROR)
+                return
+            }
+            val parseResult = NotebookJsonParser.parseHighlights(highlightsJson)
+            val highlights = parseResult.getOrNull()
+            if (highlights != null) {
+                if (!ensureHighlightsStoreReady()) {
+                    return
+                }
+                try {
+                    highlightsFileStore.addBookHighlights(currentBook, highlights)
+                } catch (e: IOException) {
+                    Log.e(TAG, "Failed to persist highlights for ASIN $currentBook.asin", e)
+                }
+                if (highlights.isEmpty()) {
+                    Log.i(TAG, "No highlights found for book '$currentBook.bookTitle' (ASIN: $currentBook.asin).")
+                } else {
+                    highlights.forEach { highlightEntry ->
+                        Log.i(
+                            TAG,
+                            "ASIN: $currentBook.asin - Highlight: \"${highlightEntry.highlight}\" --- Note: \"${highlightEntry.note}\""
+                        )
+                    }
+                }
+            } else {
+                parseResult.exceptionOrNull()?.let { e ->
+                    Log.e(TAG, "Error processing highlights for book '$currentBook.bookTitle' (ASIN: $currentBook.asin): ", e)
+                    // we continue to process highlights even though there's an error
+                }
+            }
+
+            when (val result = importStateMachine.advanceToNextBook()) {
+                is NotebookImportStateMachine.HighlightProcessingResult.Next -> {
+                    runOnUiThread { loadNextBookHighlights() }
+                }
+                NotebookImportStateMachine.HighlightProcessingResult.Completed -> {
+                    try {
+                        highlightsFileStore.flush()
+                    } catch (e: IOException) {
+                        Log.e(TAG, "Failed to flush highlights to file", e)
+                    }
+                    Log.i(TAG, "Highlight extraction complete.")
+                    terminateProcess(ImportState.FINISHED)
+                }
+                is NotebookImportStateMachine.HighlightProcessingResult.InvalidState -> {
+                    Log.e(TAG, "advanceToNextBook called in a wrong state ${result.state}. Aborting.")
+                    terminateProcess(ImportState.ERROR)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kindler/MainActivity.kt
+++ b/app/src/main/java/com/kindler/MainActivity.kt
@@ -1,276 +1,57 @@
 package com.kindler
 
-import android.annotation.SuppressLint
-import androidx.appcompat.app.AppCompatActivity
+import android.content.Intent
 import android.os.Bundle
-import android.util.Log
-import android.view.View
-import android.webkit.JavascriptInterface
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.widget.Button
-import android.widget.LinearLayout
-import android.widget.TextView
-import java.io.File
-import java.io.IOException
-import java.nio.charset.StandardCharsets
-
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.navigation.NavigationView
 
 class MainActivity : AppCompatActivity() {
 
-    companion object {
-        private const val TAG = "MainActivity"
-        private const val BASE_URL = "https://read.amazon.com/"
-        private const val NOTEBOOK_URL = "${BASE_URL}notebook"
-        private const val HIGHLIGHT_URL_PREFIX = "${BASE_URL}notebook?asin="
-        private const val HIGHLIGHT_URL_SUFFIX = "&contentLimitState="
-        private const val SIGN_IN_URL_PREFIX = "https://www.amazon.com/ap/signin"
-        private const val HIGHLIGHTS_FILE_NAME = "kindle_highlights.json"
-    }
+    private lateinit var drawerLayout: DrawerLayout
+    private lateinit var navigationView: NavigationView
+    private lateinit var toolbar: MaterialToolbar
 
-    private val importStateMachine = NotebookImportStateMachine()
-    private lateinit var myWebView: WebView
-    private lateinit var overlayLayout: LinearLayout
-    private lateinit var startImportButton: Button
-    private lateinit var promptTextView: TextView
-    private lateinit var highlightsFileStore: HighlightsFileStore
-    private var highlightsStoreResetThisRun = false
-
-    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        myWebView = findViewById(R.id.webView)
-        overlayLayout = findViewById(R.id.overlayLayout)
-        startImportButton = findViewById(R.id.startImportButton)
-        promptTextView = findViewById(R.id.promptTextView)
-        highlightsFileStore = HighlightsFileStore(File(filesDir, HIGHLIGHTS_FILE_NAME))
+        drawerLayout = findViewById(R.id.drawer_layout)
+        navigationView = findViewById(R.id.nav_view)
+        toolbar = findViewById(R.id.topAppBar)
 
-        myWebView.settings.javaScriptEnabled = true
-        myWebView.addJavascriptInterface(WebAppInterface(), "AndroidInterface")
+        setSupportActionBar(toolbar)
 
-        myWebView.webViewClient = object : WebViewClient() {
-            override fun onPageFinished(view: WebView?, url: String?) {
-                super.onPageFinished(view, url)
-                Log.i(TAG, "New page finished loading: $url")
-                Log.d(TAG, "Current state: ${importStateMachine.state}")
-                when (importStateMachine.state) {
-                    ImportState.INITIAL -> checkLoginAndUrlStatus()
-                    ImportState.LOADING_BOOK_LIST -> verifyUrlAndProceed(NOTEBOOK_URL, url, "extract_book_list.js")
-                    ImportState.LOADING_HIGHLIGHTS -> verifyUrlAndProceed(HIGHLIGHT_URL_PREFIX, url, "extract_highlights.js")
-                    else -> {
-                        // No action needed for other states
-                    }
+        val toggle = ActionBarDrawerToggle(
+            this,
+            drawerLayout,
+            toolbar,
+            R.string.navigation_drawer_open,
+            R.string.navigation_drawer_close
+        )
+        drawerLayout.addDrawerListener(toggle)
+        toggle.syncState()
+
+        navigationView.setNavigationItemSelectedListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.nav_import -> {
+                    startActivity(Intent(this, ImportActivity::class.java))
+                    drawerLayout.closeDrawer(GravityCompat.START)
+                    true
                 }
+                else -> false
             }
         }
-
-        startImportButton.setOnClickListener {
-            overlayLayout.visibility = View.GONE
-            startImportProcess()
-        }
-        
-        myWebView.loadUrl(NOTEBOOK_URL)
     }
 
-    private fun checkLoginAndUrlStatus() {
-        val script = """
-        (function() {
-            var isLoggedIn = document.getElementById('kp-notebook-library') !== null;
-            var isOnNotebookPage = window.location.href.startsWith('${NOTEBOOK_URL}');
-            var isOnSignInPage = window.location.href.startsWith('${SIGN_IN_URL_PREFIX}');
-            if (typeof AndroidInterface !== 'undefined' && AndroidInterface.reportUiStatus) {
-                AndroidInterface.reportUiStatus(isLoggedIn, isOnNotebookPage, isOnSignInPage);
-            }
-        })();
-        """.trimIndent()
-        myWebView.evaluateJavascript(script, null)
-    }
-    
-    private fun terminateProcess(finalState: ImportState) {
-        if (finalState != ImportState.FINISHED && finalState != ImportState.ERROR) {
-            Log.w(TAG, "terminateProcess called with non-terminal state: $finalState")
-            return
-        }
-        when (finalState) {
-            ImportState.FINISHED -> importStateMachine.markFinished()
-            ImportState.ERROR -> importStateMachine.markError()
-            else -> { /* Already validated above */ }
-        }
-        runOnUiThread {
-            overlayLayout.visibility = View.VISIBLE
-            checkLoginAndUrlStatus()
-        }
-    }
-
-    private fun startImportProcess(){
-        highlightsStoreResetThisRun = false
-        importStateMachine.startImport()
-        Log.d(TAG, "Starting import process. Loading book list page: $NOTEBOOK_URL")
-        myWebView.loadUrl(NOTEBOOK_URL)
-    }
-
-    private fun verifyUrlAndProceed(expectedUrlPrefix: String, actualUrl: String?, scriptToLoad: String) {
-        if (actualUrl?.startsWith(expectedUrlPrefix) == true) {
-            loadAndExecuteJavascript(myWebView, scriptToLoad)
+    override fun onBackPressed() {
+        if (drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            drawerLayout.closeDrawer(GravityCompat.START)
         } else {
-            Log.e(TAG, "URL Mismatch! State: ${importStateMachine.state}, Expected prefix: '$expectedUrlPrefix', Actual: '$actualUrl'.")
-            terminateProcess(ImportState.ERROR)
-        }
-    }
-
-    private fun loadNextBookHighlights() {
-        if (importStateMachine.state != ImportState.LOADING_HIGHLIGHTS) {
-            Log.e(TAG, "loadNextBookHighlights called in a wrong state ${importStateMachine.state}. Aborting.")
-            return
-        }
-        val book = importStateMachine.currentBook()
-        if (book == null) {
-            Log.e(
-                TAG,
-                "loadNextBookHighlights called with invalid index ${importStateMachine.currentBookIndex}. " +
-                        "Book list size: ${importStateMachine.totalBooks}. Aborting."
-            )
-            return
-        }
-        val highlightsUrl = "$HIGHLIGHT_URL_PREFIX${book.asin}$HIGHLIGHT_URL_SUFFIX"
-        Log.i(TAG, "Loading highlights for book '${book.title}' (ASIN: ${book.asin}) from $highlightsUrl")
-        myWebView.loadUrl(highlightsUrl)
-    }
-
-    private fun loadAndExecuteJavascript(webView: WebView?, scriptName: String) {
-        val javascript: String
-        try {
-            val inputStream = assets.open(scriptName)
-            val size = inputStream.available()
-            val buffer = ByteArray(size)
-            inputStream.read(buffer)
-            inputStream.close()
-            javascript = String(buffer, StandardCharsets.UTF_8)
-        } catch (e: IOException) {
-            Log.e(TAG, "Error reading $scriptName from assets", e)
-            terminateProcess(ImportState.ERROR)
-            return
-        }
-        Log.d(TAG, "Executing $scriptName")
-        webView?.evaluateJavascript(javascript, null)
-    }
-
-    private fun ensureHighlightsStoreReady(): Boolean {
-        if (highlightsStoreResetThisRun) {
-            return true
-        }
-        return try {
-            highlightsFileStore.reset()
-            highlightsStoreResetThisRun = true
-            true
-        } catch (e: IOException) {
-            Log.e(TAG, "Failed to reset highlights storage", e)
-            terminateProcess(ImportState.ERROR)
-            false
-        }
-    }
-
-    inner class WebAppInterface {
-        @JavascriptInterface
-        fun reportUiStatus(isLoggedIn: Boolean, isOnNotebookPage: Boolean, isOnSignInPage: Boolean) {
-            runOnUiThread {
-                if (isLoggedIn && isOnNotebookPage) {
-                    promptTextView.text = "Import your Kindle books and highlights."
-                    startImportButton.visibility = View.VISIBLE
-                } else if (isOnSignInPage || isOnNotebookPage) {
-                    promptTextView.text = "Please log in to your Amazon account to continue."
-                    startImportButton.visibility = View.GONE
-                } else{
-                    promptTextView.text = "Please navigate to your Kindle Notebook page."
-                    startImportButton.visibility = View.GONE
-                }
-            }
-        }
-
-        @JavascriptInterface
-        fun processBookData(bookDataJson: String) {
-            if (importStateMachine.state != ImportState.LOADING_BOOK_LIST) return
-            Log.i(TAG, "Received book list data. Processing...")
-            NotebookJsonParser.parseBookEntries(bookDataJson)
-                .onSuccess { parsedBooks ->
-                    Log.i(TAG, "Total books found on main page: ${parsedBooks.size}")
-                    when (val result = importStateMachine.onBooksParsed(parsedBooks)) {
-                        NotebookImportStateMachine.BooksUpdateResult.NoBooks -> {
-                            Log.i(TAG, "No books found in the list. Finishing process.")
-                            terminateProcess(ImportState.FINISHED)
-                        }
-                        is NotebookImportStateMachine.BooksUpdateResult.Ready -> {
-                            runOnUiThread { loadNextBookHighlights() }
-                        }
-                        is NotebookImportStateMachine.BooksUpdateResult.InvalidState -> {
-                            Log.e(TAG, "Received book data while in invalid state ${result.state}.")
-                            terminateProcess(ImportState.ERROR)
-                        }
-                    }
-                }
-                .onFailure { e ->
-                    Log.e(TAG, "Error processing book list data: ", e)
-                    terminateProcess(ImportState.ERROR)
-                }
-        }
-
-        @JavascriptInterface
-        fun processBookHighlights(highlightsJson: String) {
-            if (importStateMachine.state != ImportState.LOADING_HIGHLIGHTS) return
-            val currentBook = importStateMachine.currentBook()
-            if (currentBook == null || currentBook.asin.isEmpty())  {
-                Log.e(TAG, "No book data available for the current book. Aborting.")
-                terminateProcess(ImportState.ERROR)
-                return
-            }
-            val parseResult = NotebookJsonParser.parseHighlights(highlightsJson)
-            val highlights = parseResult.getOrNull()
-            if (highlights != null) {
-                if (!ensureHighlightsStoreReady()) {
-                    return
-                }
-                try {
-                    highlightsFileStore.addBookHighlights(currentBook, highlights)
-                } catch (e: IOException) {
-                    Log.e(TAG, "Failed to persist highlights for ASIN $currentBook.asin", e)
-                }
-                if (highlights.isEmpty()) {
-                    Log.i(TAG, "No highlights found for book '$currentBook.bookTitle' (ASIN: $currentBook.asin).")
-                } else {
-                    highlights.forEach { highlightEntry ->
-                        Log.i(
-                            TAG,
-                            "ASIN: $currentBook.asin - Highlight: \"${highlightEntry.highlight}\" --- Note: \"${highlightEntry.note}\""
-                        )
-                    }
-                }
-            } else {
-                parseResult.exceptionOrNull()?.let { e ->
-                    Log.e(TAG, "Error processing highlights for book '$currentBook.bookTitle' (ASIN: $currentBook.asin): ", e)
-                    // we continue to process highlights even though there's an error
-                }
-            }
-
-            when (val result = importStateMachine.advanceToNextBook()) {
-                is NotebookImportStateMachine.HighlightProcessingResult.Next -> {
-                    runOnUiThread { loadNextBookHighlights() }
-                }
-                NotebookImportStateMachine.HighlightProcessingResult.Completed -> {
-                    try {
-                        highlightsFileStore.flush()
-                    } catch (e: IOException) {
-                        Log.e(TAG, "Failed to flush highlights to file", e)
-                    }
-                    Log.i(TAG, "Highlight extraction complete.")
-                    terminateProcess(ImportState.FINISHED)
-                }
-                is NotebookImportStateMachine.HighlightProcessingResult.InvalidState -> {
-                    Log.e(TAG, "advanceToNextBook called in a wrong state ${result.state}. Aborting.")
-                    terminateProcess(ImportState.ERROR)
-                }
-            }
+            super.onBackPressed()
         }
     }
 }

--- a/app/src/main/res/layout/activity_import.xml
+++ b/app/src/main/res/layout/activity_import.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".ImportActivity">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!-- Overlay Layout -->
+    <LinearLayout
+        android:id="@+id/overlayLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:background="#80000000"
+        android:visibility="visible">
+
+        <TextView
+            android:id="@+id/promptTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Navigate to your Kindle Notebook page and log in if necessary."
+            android:textColor="@android:color/white"
+            android:textSize="18sp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="16dp"/>
+
+        <Button
+            android:id="@+id/startImportButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Start Import"
+            android:layout_gravity="center_horizontal"
+            android:visibility="gone"/>
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,48 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
-    <WebView
-        android:id="@+id/webView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-    <!-- Overlay Layout -->
     <LinearLayout
-        android:id="@+id/overlayLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:background="#80000000"
-        android:visibility="visible">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/promptTextView"
-            android:layout_width="wrap_content"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/topAppBar"
+            style="@style/Widget.Material3.Toolbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Navigate to your Kindle Notebook page and log in if necessary."
-            android:textColor="@android:color/white"
-            android:textSize="18sp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginBottom="16dp"/>
+            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+            app:title="@string/app_title" />
 
-        <Button
-            android:id="@+id/startImportButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Start Import"
-            android:layout_gravity="center_horizontal"
-            android:visibility="gone"/>
+        <FrameLayout
+            android:id="@+id/content_frame"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:padding="24dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_placeholder"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+        </FrameLayout>
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:fitsSystemWindows="true"
+        app:menu="@menu/main_drawer" />
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/menu/main_drawer.xml
+++ b/app/src/main/res/menu/main_drawer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_import"
+        android:title="@string/nav_import" />
+    <item
+        android:id="@+id/nav_show"
+        android:enabled="false"
+        android:title="@string/nav_show" />
+    <item
+        android:id="@+id/nav_export"
+        android:enabled="false"
+        android:title="@string/nav_export" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">Kindler</string>
+    <string name="app_title">My Highlights</string>
+    <string name="main_placeholder">Select an option from the menu to get started.</string>
+    <string name="navigation_drawer_open">Open navigation drawer</string>
+    <string name="navigation_drawer_close">Close navigation drawer</string>
+    <string name="nav_import">Import</string>
+    <string name="nav_show">Show</string>
+    <string name="nav_export">Export</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a navigation drawer with a My Highlights toolbar and Import/Show/Export items
- disable the Show and Export entries until their screens exist and launch the import flow from the drawer
- move the existing import WebView implementation into a dedicated ImportActivity and layout

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59bda59c88332bca16e57185360fe