### PR TITLE
Set import as default and improve navigation icon

### DIFF
--- a/app/src/main/java/com/kindler/MainActivity.kt
+++ b/app/src/main/java/com/kindler/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.appbar.MaterialToolbar
@@ -34,6 +35,7 @@ class MainActivity : AppCompatActivity() {
         )
         drawerLayout.addDrawerListener(toggle)
         toggle.syncState()
+        toggle.drawerArrowDrawable.color = ContextCompat.getColor(this, R.color.black)
 
         navigationView.setNavigationItemSelectedListener { menuItem ->
             when (menuItem.itemId) {
@@ -44,6 +46,11 @@ class MainActivity : AppCompatActivity() {
                 }
                 else -> false
             }
+        }
+
+        if (savedInstanceState == null) {
+            navigationView.setCheckedItem(R.id.nav_import)
+            navigationView.menu.performIdentifierAction(R.id.nav_import, 0)
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,14 +26,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:padding="24dp">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/main_placeholder"
-                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
-        </FrameLayout>
+            android:padding="24dp" />
     </LinearLayout>
 
     <com.google.android.material.navigation.NavigationView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <resources>
     <string name="app_name">Kindler</string>
     <string name="app_title">My Highlights</string>
-    <string name="main_placeholder">Select an option from the menu to get started.</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="nav_import">Import</string>


### PR DESCRIPTION
## Summary
- remove the placeholder content from the main screen and automatically select the Import navigation item on launch
- tint the drawer toggle so the hamburger icon is visible on the light background
- remove the unused `main_placeholder` string resource left behind after deleting the placeholder view

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a2e9bf988332aeb5c8bd14e86104