### PR TITLE
Fix navigation drawer layout and improve contrast

### DIFF
--- a/app/src/main/res/color/nav_drawer_item_icon_tint.xml
+++ b/app/src/main/res/color/nav_drawer_item_icon_tint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="?attr/colorPrimary" />
+    <item android:state_enabled="false" android:color="?attr/colorOutline" />
+    <item android:color="?attr/colorOnSurfaceVariant" />
+</selector>

--- a/app/src/main/res/color/nav_drawer_item_text_color.xml
+++ b/app/src/main/res/color/nav_drawer_item_text_color.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="?attr/colorPrimary" />
+    <item android:state_enabled="false" android:color="?attr/colorOutline" />
+    <item android:color="?attr/colorOnSurface" />
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,26 +8,31 @@
     android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
-    <LinearLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/topAppBar"
-            style="@style/Widget.Material3.Toolbar"
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
-            app:title="@string/app_title" />
+            android:fitsSystemWindows="true">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/topAppBar"
+                style="@style/Widget.Material3.Toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+                app:title="@string/app_title" />
+        </com.google.android.material.appbar.AppBarLayout>
 
         <FrameLayout
             android:id="@+id/content_frame"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:padding="24dp" />
-    </LinearLayout>
+            android:layout_height="match_parent"
+            android:padding="24dp"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/nav_view"
@@ -35,6 +40,9 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
+        android:background="?attr/colorSurface"
+        app:itemIconTint="@color/nav_drawer_item_icon_tint"
+        app:itemTextColor="@color/nav_drawer_item_text_color"
         app:menu="@menu/main_drawer" />
 
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
## Summary
- restructure the main activity layout to use CoordinatorLayout and AppBarLayout so the navigation drawer renders without being clipped
- provide dedicated color selectors for navigation drawer items and apply them to ensure accessible contrast

## Testing
- ./gradlew lintDebug *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc24358ca08332b3736e8b54fee278