### PR TITLE
Show load more button when scrolled to bottom

### DIFF
--- a/app/src/main/java/com/kindler/DisplayFragment.kt
+++ b/app/src/main/java/com/kindler/DisplayFragment.kt
@@ -42,6 +42,10 @@ class DisplayFragment : Fragment() {
         contentLayout = view.findViewById(R.id.contentLayout)
         loadMoreButton = view.findViewById(R.id.loadMoreButton)
 
+        scrollView.viewTreeObserver.addOnScrollChangedListener {
+            updateLoadMoreButton()
+        }
+
         highlightsFileStore = HighlightsFileStore(
             File(requireContext().filesDir, HIGHLIGHTS_FILE_NAME)
         )
@@ -95,19 +99,25 @@ class DisplayFragment : Fragment() {
             Log.e(TAG, "Unexpected error loading highlights", e)
             showCorruptedState()
         } finally {
-            loadMoreButton.isEnabled = hasMoreBooks
+            updateLoadMoreButton()
         }
     }
 
     private fun updateLoadMoreButton() {
-        if (hasMoreBooks) {
+        val shouldShowLoadMore = hasMoreBooks && isScrolledToBottom()
+
+        if (shouldShowLoadMore) {
             loadMoreButton.visibility = View.VISIBLE
             loadMoreButton.text = getString(R.string.load_more)
-            loadMoreButton.isEnabled = true
         } else {
             loadMoreButton.visibility = View.GONE
-            loadMoreButton.isEnabled = false
         }
+
+        loadMoreButton.isEnabled = shouldShowLoadMore
+    }
+
+    private fun isScrolledToBottom(): Boolean {
+        return !scrollView.canScrollVertically(1)
     }
 
     private fun addBookView(book: BookEntry) {


### PR DESCRIPTION
## Summary
- add a scroll listener to refresh the load more button state as the user scrolls
- only show and enable the load more button when additional books exist and the list is scrolled to the bottom

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b167c8a88332bbef015b5b935885