### PR TITLE
Place load more button at end of book list

### DIFF
--- a/app/src/main/java/com/kindler/DisplayFragment.kt
+++ b/app/src/main/java/com/kindler/DisplayFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
-import android.widget.ScrollView
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import java.io.File
@@ -20,7 +19,6 @@ class DisplayFragment : Fragment() {
         private const val HIGHLIGHTS_FILE_NAME = "kindle_highlights.json"
     }
 
-    private lateinit var scrollView: ScrollView
     private lateinit var contentLayout: LinearLayout
     private lateinit var loadMoreButton: Button
     private lateinit var highlightsFileStore: HighlightsFileStore
@@ -38,7 +36,6 @@ class DisplayFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        scrollView = view.findViewById(R.id.displayScrollView)
         contentLayout = view.findViewById(R.id.contentLayout)
         loadMoreButton = view.findViewById(R.id.loadMoreButton)
 
@@ -95,7 +92,7 @@ class DisplayFragment : Fragment() {
             Log.e(TAG, "Unexpected error loading highlights", e)
             showCorruptedState()
         } finally {
-            loadMoreButton.isEnabled = hasMoreBooks
+            updateLoadMoreButton()
         }
     }
 
@@ -103,11 +100,10 @@ class DisplayFragment : Fragment() {
         if (hasMoreBooks) {
             loadMoreButton.visibility = View.VISIBLE
             loadMoreButton.text = getString(R.string.load_more)
-            loadMoreButton.isEnabled = true
         } else {
             loadMoreButton.visibility = View.GONE
-            loadMoreButton.isEnabled = false
         }
+        loadMoreButton.isEnabled = hasMoreBooks
     }
 
     private fun addBookView(book: BookEntry) {

--- a/app/src/main/res/layout/fragment_display.xml
+++ b/app/src/main/res/layout/fragment_display.xml
@@ -9,29 +9,35 @@
         android:id="@+id/displayScrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:padding="16dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/loadMoreButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:padding="16dp">
-
-        <LinearLayout
-            android:id="@+id/contentLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-
-    </ScrollView>
-
-    <Button
-        android:id="@+id/loadMoreButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/load_more"
-        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_margin="16dp" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/contentLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <Button
+                android:id="@+id/loadMoreButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="16dp"
+                android:text="@string/load_more"
+                android:visibility="gone" />
+
+        </LinearLayout>
+
+    </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- move the Load More button inside the scrollable content so it appears after the list of books
- simplify the visibility logic so the button only depends on whether additional books are available

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b167c8a88332bbef015b5b935885